### PR TITLE
Added Pdfcrop functionality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,11 @@ Config values
     Use the verbose mode when call mermaid-cli, and show its output in the building
     process.
 
+``mermaid_pdfcrop``
+
+    If using latex output, it might be useful to crop the pdf just to the needed space. For this, ``pdfcrop`` can be used.
+    State binary name to use this extra function.
+
 Acknowledge
 -----------
 


### PR DESCRIPTION
Hi,
I have a proposition for more functionality, but it will bring an additional dependency.

With this patch, you can use the mermaid_pdfcrop directive to use the pdfcrop utility on linux systems.
It will crop the pdf output of mermaid to the useful area so that an image that is not the default width/height doesn't take up too much space.

BR Bastian